### PR TITLE
Nicer format in print output

### DIFF
--- a/actions/paper
+++ b/actions/paper
@@ -28,7 +28,7 @@ get_tasks_raw(){
 		return 1
 	fi
 
-	cat "$src"
+	/usr/bin/todo.sh -p ls
 }
 
 get_tasks_markdown(){


### PR DESCRIPTION
The default `todo.sh paper` uses unpadded task numbers (1, 2, ... 10); `todo.sh ls` however uses padded numbers (01, 02, ...10) and looks nicer when printed.